### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ which makes it great to use for [React's `key={}`](https://facebook.github.io/re
 
 ```js
 import key from 'weak-key';
-export default function Todo(items) {
+export default function Todo({ items }) {
   return (
     <ul>
       {


### PR DESCRIPTION
Fixes the 'usage with react' example in the readme. Currently it attempts to use `items` where it actually refers to the entire `props` object. This PR updates the example to instead destructure `items` from `props` inline