### PR TITLE
Upgrade core-js dependency to v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var WeakMap = global.WeakMap || require('core-js/library/fn/weak-map');
+var WeakMap = global.WeakMap || require('core-js/stable/weak-map');
 var map = new WeakMap();
 var index = 0;
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Moshe Kolodny",
   "license": "MIT",
   "dependencies": {
-    "core-js": "^2.4.0"
+    "core-js": "^3.26.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",


### PR DESCRIPTION
As can be seen every time we install this package, core-js 2.x is deprecated:

> core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.

This shouldn't be a breaking change so could be released as a patch release 🚀 