### PR TITLE
Remove dependency on core-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var WeakMap = global.WeakMap || require('core-js/library/fn/weak-map');
 var map = new WeakMap();
 var index = 0;
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   ],
   "author": "Moshe Kolodny",
   "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.0"
-  },
   "devDependencies": {
     "coveralls": "^2.11.9",
     "expect": "^1.20.1",


### PR DESCRIPTION
Migration Guide:

This module does not support IE 10 and earlier anymore. To continue using this module on older runtimes, you need to polyfill WeakMap globally.